### PR TITLE
Fixes to support python3 and made initiators more flexible

### DIFF
--- a/dellemc_ansible/powermax/library/dellemc_powermax_hostgroup.py
+++ b/dellemc_ansible/powermax/library/dellemc_powermax_hostgroup.py
@@ -363,7 +363,7 @@ class PowerMaxHostGroup(object):
             for host in hostgroup['host']:
                 existing_hosts.append(host['hostId'])
 
-        if hosts and cmp(existing_hosts, hosts) == 0:
+        if hosts and len(set(hosts)-set(existing_hosts)) == 0:
             LOG.info('Hosts are already present in host group {0}'
                      .format(hostgroup_name))
             return False
@@ -515,7 +515,7 @@ class PowerMaxHostGroup(object):
             else:
                 self._enable_consistent_lun(new_flags_dict)
 
-        if cmp(new_flags_dict, current_flags) == 0:
+        if self._is_dict_same(new_flags_dict, current_flags):
             LOG.info('No change detected')
             self.module.exit_json(changed=False)
         else:
@@ -532,6 +532,26 @@ class PowerMaxHostGroup(object):
                 LOG.error(errorMsg)
                 self.module.fail_json(msg=errorMsg)
             return None
+
+    def _is_dict_same(self,d1, d2, path=""):
+        '''
+        Compares two nested dictionaries to see if there is a difference
+        '''
+        for k in d1.keys():
+            if k not in d2:
+                return False
+            else:
+                if type(d1[k]) is dict:
+                    if path == "":
+                        path = k
+                    else:
+                        path = path + "->" + k
+                    if not self._is_dict_same(d1[k],d2[k], path):
+                        return False
+                else:
+                    if d1[k] != d2[k]:
+                        return False
+        return True
 
     def _create_result_dict(self, changed):
         self.result['changed'] = changed


### PR DESCRIPTION
On the `dellemc_powermax_host` module you used the `cmp` method. It is no longer available in Python3, and that is the default moving forward for Ansible.  

If the input was a list of strings, I just used a quick comparison after conversion to sets to obtain the same result. For a complex dictionary, I found a function someone wrote and changed it to our use case of returning a bool value.

As an additional user usability feature, I created a method to get the user provided WWPN's that normalizes it to the input the VMAX is looking for. AKA strip out the colons, and force everything to lowercase. This makes it so we don't have to do that in Jinja outside of the module. Most OEM API's return the WWPN in all caps, and with the colon.