### PR TITLE
Fix issue when renaming volume created without a name

### DIFF
--- a/plugins/modules/dellemc_powermax_volume.py
+++ b/plugins/modules/dellemc_powermax_volume.py
@@ -875,10 +875,13 @@ class PowerMaxVolume(object):
                 self.show_error_exit(msg="Please provide valid volume "
                                          "name.")
 
-            vol_name = vol['volume_identifier']
-            if new_name != vol_name:
-                LOG.info('Changing the name of volume %s to %s',
-                         vol_name, new_name)
+            if 'volume_identifier' in vol:
+                vol_name = vol['volume_identifier']
+                if new_name != vol_name:
+                    LOG.info('Changing the name of volume %s to %s',
+                             vol_name, new_name)
+                    changed = self.rename_volume(vol_id, new_name) or changed
+            else:
                 changed = self.rename_volume(vol_id, new_name) or changed
 
         if state == 'absent' and vol:


### PR DESCRIPTION
I have found that is is currently not possible to rename a volume that was created without name.
In fact, creating a volume in a storage group (use with SRDF metro) do not propagate the vol_name to the R2 so I tried to rename it using the new_name parameter and this does not work. Attempting to rename such volumes led to a dictionary key exception (the volume_identifier key is not defined in the vol dictionary).
