### PR TITLE
Update portgroup.py

### DIFF
--- a/plugins/modules/portgroup.py
+++ b/plugins/modules/portgroup.py
@@ -506,7 +506,7 @@ def get_portgroup_parameters():
         port_state=dict(required=False, type='str',
                         choices=['present-in-group', 'absent-in-group']),
         port_group_protocol=dict(required=False, type='str',
-                                 choices=['SCSI_FC', 'iSCSI', 'NVMe_TCP']),
+                                 choices=['SCSI_FC', 'iSCSI', 'NVMe_TCP', 'NVMe_FC']),
         new_name=dict(required=False, type='str')
     )
 


### PR DESCRIPTION
Added the NVMe_FC option

# Description
Added the option for NVMe_FC as a port group option like in the GUI.

# GitHub Issues
List the GitHub issues impacted by this PR: N/A

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
We have a Powermax 2500 in the lab that we used to confirm this change worked as expected.
- [x] We had all ports on the array set to NVMe/FC and then created a portgroup with the new choice and it configured the portgroup as expected with the proper director and ports.  

