### PR TITLE
Remove SRDF Force flag, it was removed in 10.2

### DIFF
--- a/plugins/modules/srdf.py
+++ b/plugins/modules/srdf.py
@@ -538,7 +538,6 @@ class SRDF(object):
             establish_flag = self._compute_required_establish_flag(
                 self.module.params['srdf_state'])
             rdfg_number = self.module.params['rdfg_no']
-            forceNewRdfGroup = self.module.params['new_rdf_group']
             async_flag = not (self.module.params['wait_for_completion'])
             witness = self.module.params['witness']
 
@@ -553,7 +552,6 @@ class SRDF(object):
                    ', srdfmode= ', srdf_mode,
                    ', establish_flag= ', establish_flag,
                    ', rdfgroup_no= ', rdfg_number,
-                   ', new_rdf_group= ', forceNewRdfGroup,
                    ', async_flag= ', async_flag
                    )
             LOG.info(msg)
@@ -565,7 +563,6 @@ class SRDF(object):
                         remote_sid=remote_serial_no,
                         srdf_mode=srdf_mode,
                         establish=establish_flag,
-                        force_new_rdf_group=forceNewRdfGroup,
                         rdfg_number=rdfg_number,
                         _async=async_flag)
                 elif self.module.params['wait_for_completion'] is True:
@@ -574,7 +571,6 @@ class SRDF(object):
                         remote_sid=remote_serial_no,
                         srdf_mode=srdf_mode,
                         establish=establish_flag,
-                        force_new_rdf_group=forceNewRdfGroup,
                         rdfg_number=rdfg_number,
                         _async=True)
                     link_status = self.get_created_srdf_link_status(job)


### PR DESCRIPTION
# Description
- Remove the `forceNewRdfGroup` as it was removed in PowerMax 10.2

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] FT
