### PR TITLE
feat: Support SRDF storage groups with different R1 and R2 names

### DIFF
--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -340,3 +340,47 @@ def is_array_v4():
     curr_version = PyU4V.__version__
     if curr_version.startswith("10"):
         return True
+
+
+def resolve_remote_sg_name(replication, sg_name, explicit_target=None,
+                           auto_resolve=False, rdfg_number=None):
+    '''Resolve the remote (R2) storage group name for SRDF operations.
+
+    Priority: explicit_target > auto_resolve > fallback to sg_name.
+
+    Parameters:
+        replication   - PyU4V replication object
+        sg_name       - local (R1) storage group name
+        explicit_target - user-provided R2 SG name (rdf_target_sg_name)
+        auto_resolve  - if True, query the array for the actual R2 name
+        rdfg_number   - RDFG number to match when auto-resolving
+
+    Returns:
+        str - the resolved remote storage group name
+    '''
+    if explicit_target:
+        return explicit_target
+
+    if auto_resolve:
+        try:
+            details = replication.get_storage_group_replication_details(
+                storage_group_id=sg_name)
+            remote_sgs = details.get('remote_storage_groups', [])
+            if not remote_sgs:
+                return sg_name
+            if len(remote_sgs) == 1:
+                return remote_sgs[0].get(
+                    'remoteStorageGroupName', sg_name)
+            if rdfg_number is not None:
+                for rsg in remote_sgs:
+                    if rsg.get('rdfGroupNumber') == rdfg_number:
+                        return rsg.get(
+                            'remoteStorageGroupName', sg_name)
+            raise Exception(
+                "Multiple SRDF groups found for storage group "
+                "{0}. Specify rdfg_number or rdf_target_sg_name "
+                "to disambiguate.".format(sg_name))
+        except Exception:
+            raise
+
+    return sg_name

--- a/plugins/modules/srdf.py
+++ b/plugins/modules/srdf.py
@@ -108,9 +108,32 @@ options:
       True.
     required: false
     type: bool
+  rdf_target_sg_name:
+    description:
+    - The name of the remote (R2) storage group on the target array.
+    - Used when the R2 storage group should have a different name from the R1 (source) storage group.
+    - If not specified, the R1 storage group name is used as the R2 storage group name.
+    - Applicable only when creating an SRDF link.
+    required: false
+    type: str
 '''
 
 EXAMPLES = r'''
+- name: Create SRDF pair with a different R2 storage group name
+  register: Job_details_body
+  dellemc.powermax.srdf:
+    unispherehost: "{{unispherehost}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    serial_no: "{{serial_no}}"
+    sg_name: "prod_sg"
+    remote_serial_no: "{{remote_serial_no}}"
+    srdf_mode: 'Synchronous'
+    srdf_state: 'Establish'
+    state: 'present'
+    rdf_target_sg_name: "DR_prod_sg"
+
 - name: Create and establish storagegroup SRDF/a pairing
   register: Job_details_body
   dellemc.powermax.srdf:
@@ -446,7 +469,8 @@ class SRDF(object):
             wait_for_completion=dict(type='bool', required=False,
                                      default=False),
             witness=dict(type='bool', required=False),
-            job_id=dict(type='str', required=False))
+            job_id=dict(type='str', required=False),
+            rdf_target_sg_name=dict(type='str', required=False))
 
     def get_srdf_link(self, sg_name):
         '''

--- a/plugins/modules/storagegroup.py
+++ b/plugins/modules/storagegroup.py
@@ -103,6 +103,22 @@ options:
      - Describes the state of snapshot policy for an SG.
     type: str
     choices: [present-in-group, absent-in-group]
+  rdf_target_sg_name:
+    description:
+    - The name of the remote (R2) storage group on the target array.
+    - Used when the R2 storage group has a different name from the R1 (source) storage group.
+    - If not specified and I(rdf_auto_resolve_target) is false, the R1 storage group name is used.
+    - Applicable only for SRDF-protected storage groups.
+    type: str
+    required: false
+  rdf_auto_resolve_target:
+    description:
+    - When true, automatically queries the array to discover the actual remote storage group name.
+    - Ignored if I(rdf_target_sg_name) is specified.
+    - Applicable only for SRDF-protected storage groups.
+    type: bool
+    required: false
+    default: false
   host_io_limit:
     description:
     - Host I/O limit of the storage group.
@@ -201,6 +217,38 @@ EXAMPLES = r'''
         size: 1
         cap_unit: "GB"
     vol_state: "present-in-group"
+
+- name: Add volumes to SRDF-protected SG with different R2 name
+  dellemc.powermax.storagegroup:
+    unispherehost: "{{unispherehost}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    serial_no: "{{serial_no}}"
+    sg_name: "prod_sg"
+    state: "present"
+    volumes:
+      - vol_name: "data_vol"
+        size: 10
+        cap_unit: "GB"
+    vol_state: "present-in-group"
+    rdf_target_sg_name: "DR_prod_sg"
+
+- name: Add volumes to SRDF-protected SG with auto-resolved R2 name
+  dellemc.powermax.storagegroup:
+    unispherehost: "{{unispherehost}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    serial_no: "{{serial_no}}"
+    sg_name: "prod_sg"
+    state: "present"
+    volumes:
+      - vol_name: "data_vol"
+        size: 10
+        cap_unit: "GB"
+    vol_state: "present-in-group"
+    rdf_auto_resolve_target: true
 
 - name: Remove volumes from existing SG
   dellemc.powermax.storagegroup:
@@ -895,7 +943,11 @@ class StorageGroup(object):
                                 rdfg_details = self.replication.\
                                     get_rdf_group(rdf_number=rdfg_list[0])
                                 remote_array = rdfg_details['remoteSymmetrix']
-                                remote_array_sg = sg_name
+                                remote_array_sg = utils.resolve_remote_sg_name(
+                                    self.replication, sg_name,
+                                    explicit_target=self.module.params.get('rdf_target_sg_name'),
+                                    auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                                    rdfg_number=rdfg_list[0])
 
                                 msg = ("Creating volume with parameters:"
                                        "storage_group_id= ", sg_name,
@@ -930,11 +982,19 @@ class StorageGroup(object):
                                 rdfg_details = self.replication. \
                                     get_rdf_group(rdf_number=rdfg_list[0])
                                 remote_array_1 = rdfg_details['remoteSymmetrix']
-                                remote_array_1_sg = sg_name
+                                remote_array_1_sg = utils.resolve_remote_sg_name(
+                                    self.replication, sg_name,
+                                    explicit_target=self.module.params.get('rdf_target_sg_name'),
+                                    auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                                    rdfg_number=rdfg_list[0])
                                 rdfg_details = self.replication. \
                                     get_rdf_group(rdf_number=rdfg_list[1])
                                 remote_array_2 = rdfg_details['remoteSymmetrix']
-                                remote_array_2_sg = sg_name
+                                remote_array_2_sg = utils.resolve_remote_sg_name(
+                                    self.replication, sg_name,
+                                    explicit_target=self.module.params.get('rdf_target_sg_name'),
+                                    auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                                    rdfg_number=rdfg_list[1])
                                 msg = ("Creating volume with parameters:"
                                        "storage_group_id= ", sg_name,
                                        ", num_vols= ", 1,
@@ -1094,7 +1154,12 @@ class StorageGroup(object):
                 rdfg_details = self.replication.get_rdf_group(rdf_number=rdfg)
 
                 params["remote_array_" + str(i) + "_id"] = rdfg_details['remoteSymmetrix']
-                params["remote_array_" + str(i) + "_sgs"] = [sg_name]
+                resolved_sg = utils.resolve_remote_sg_name(
+                    self.replication, sg_name,
+                    explicit_target=self.module.params.get('rdf_target_sg_name'),
+                    auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                    rdfg_number=rdfg)
+                params["remote_array_" + str(i) + "_sgs"] = [resolved_sg]
 
             if not self.module.check_mode:
                 self.provisioning.add_existing_volume_to_storage_group(**params)
@@ -1162,11 +1227,19 @@ class StorageGroup(object):
                     rdfg_details = self.replication. \
                         get_rdf_group(rdf_number=rdfg_list[0])
                     remote_array_1 = rdfg_details['remoteSymmetrix']
-                    remote_array_1_sg = sg_name
+                    remote_array_1_sg = utils.resolve_remote_sg_name(
+                        self.replication, sg_name,
+                        explicit_target=self.module.params.get('rdf_target_sg_name'),
+                        auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                        rdfg_number=rdfg_list[0])
                     rdfg_details = self.replication. \
                         get_rdf_group(rdf_number=rdfg_list[1])
                     remote_array_2 = rdfg_details['remoteSymmetrix']
-                    remote_array_2_sg = sg_name
+                    remote_array_2_sg = utils.resolve_remote_sg_name(
+                        self.replication, sg_name,
+                        explicit_target=self.module.params.get('rdf_target_sg_name'),
+                        auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                        rdfg_number=rdfg_list[1])
                     for vol in volumes_to_remove:
                         if not self.module.check_mode:
                             self.provisioning.remove_volume_from_storage_group(
@@ -1188,7 +1261,11 @@ class StorageGroup(object):
                 rdfg_details = self.replication.\
                     get_rdf_group(rdf_number=rdfg_list[0])
                 remote_array = rdfg_details['remoteSymmetrix']
-                remote_array_sg = sg_name
+                remote_array_sg = utils.resolve_remote_sg_name(
+                    self.replication, sg_name,
+                    explicit_target=self.module.params.get('rdf_target_sg_name'),
+                    auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                    rdfg_number=rdfg_list[0])
 
             for vol in volumes_to_remove:
                 if not self.module.check_mode:
@@ -1892,6 +1969,8 @@ def get_storage_group_parameters():
                 'present-in-group',
                 'absent-in-group']),
         target_sg_name=dict(type='str'),
+        rdf_target_sg_name=dict(type='str', required=False),
+        rdf_auto_resolve_target=dict(type='bool', required=False, default=False),
         force=dict(type='bool'),
         host_io_limit=dict(required=False, type='dict',
                            options=dict(host_io_limit_mbps=dict(required=False, type='int'),

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -64,6 +64,22 @@ options:
     description:
     - Appends volume id to the volume name, Applicable from V4 (Juniper).
     type: bool
+  rdf_target_sg_name:
+    description:
+    - The name of the remote (R2) storage group on the target array.
+    - Used when the R2 storage group has a different name from the R1 (source) storage group.
+    - If not specified and I(rdf_auto_resolve_target) is false, the R1 storage group name is used.
+    - Applicable only when creating volumes in SRDF-protected storage groups.
+    type: str
+    required: false
+  rdf_auto_resolve_target:
+    description:
+    - When true, automatically queries the array to discover the actual remote storage group name.
+    - Ignored if I(rdf_target_sg_name) is specified.
+    - Applicable only when creating volumes in SRDF-protected storage groups.
+    type: bool
+    required: false
+    default: false
   state:
     description:
     - Defines whether the volume should exist or not.
@@ -662,11 +678,19 @@ class Volume(object):
                         rdfg_details = self.replication.\
                             get_rdf_group(rdf_number=rdfg_list[0])
                         remote_array_1 = rdfg_details['remoteSymmetrix']
-                        remote_array_1_sg = sg_name
+                        remote_array_1_sg = utils.resolve_remote_sg_name(
+                            self.replication, sg_name,
+                            explicit_target=self.module.params.get('rdf_target_sg_name'),
+                            auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                            rdfg_number=rdfg_list[0])
                         rdfg_details = self.replication. \
                             get_rdf_group(rdf_number=rdfg_list[1])
                         remote_array_2 = rdfg_details['remoteSymmetrix']
-                        remote_array_2_sg = sg_name
+                        remote_array_2_sg = utils.resolve_remote_sg_name(
+                            self.replication, sg_name,
+                            explicit_target=self.module.params.get('rdf_target_sg_name'),
+                            auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                            rdfg_number=rdfg_list[1])
                         msg = ('Creating volume with parameters:'
                                'storage_group_id= ', sg_name,
                                ', num_vols= ', 1,
@@ -709,7 +733,11 @@ class Volume(object):
                     rdfg_details = self.replication. \
                         get_rdf_group(rdf_number=rdfg_list[0])
                     remote_array = rdfg_details['remoteSymmetrix']
-                    remote_array_sg = sg_name
+                    remote_array_sg = utils.resolve_remote_sg_name(
+                        self.replication, sg_name,
+                        explicit_target=self.module.params.get('rdf_target_sg_name'),
+                        auto_resolve=self.module.params.get('rdf_auto_resolve_target', False),
+                        rdfg_number=rdfg_list[0])
 
             # Create new volume and add to storage group
             msg = ('Creating volume with parameters:'
@@ -988,6 +1016,8 @@ def get_volume_parameters():
         cap_unit=dict(choices=['MB', 'GB', 'TB', 'CYL'], type='str'),
         vol_wwn=dict(required=False, type='str'),
         append_vol_id=dict(required=False, type='bool'),
+        rdf_target_sg_name=dict(type='str', required=False),
+        rdf_auto_resolve_target=dict(type='bool', required=False, default=False),
         state=dict(required=True, type='str', choices=['absent', 'present'])
     )
 

--- a/tests/unit/plugins/module_utils/mock_srdf_api.py
+++ b/tests/unit/plugins/module_utils/mock_srdf_api.py
@@ -1,0 +1,102 @@
+# Copyright: (c) 2024-2025, Dell Technologies
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Mock SRDF Api for SRDF Test module on PowerMax
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class MockSRDFApi:
+    SRDF_COMMON_ARGS = {
+        "sg_name": "test_sg",
+        "remote_serial_no": "000297900330",
+        "state": "present",
+        "srdf_state": "Establish",
+        "srdf_mode": "Synchronous",
+        "rdfg_no": 1,
+        "wait_for_completion": False,
+        "witness": True,
+        "job_id": None,
+        "rdf_target_sg_name": None,
+    }
+
+    SRDF_LINK_DETAILS = {
+        "storageGroupName": "test_sg",
+        "symmetrixId": "000197600156",
+        "rdfGroupNumber": 1,
+        "modes": ["Synchronous"],
+        "states": ["Synchronized"],
+        "remoteSymmetrix": "000297900330",
+        "totalTracks": 1000,
+        "volumeRdfTypes": ["R1"],
+    }
+
+    SRDF_LINK_DETAILS_LIST = [SRDF_LINK_DETAILS]
+
+    RDF_GROUP_DETAILS = {
+        "rdfgNumber": 1,
+        "remoteSymmetrix": "000297900330",
+        "label": "test_rdfg",
+        "numDevices": 5,
+        "modes": ["Synchronous"],
+        "states": ["Synchronized"],
+    }
+
+    JOB_DETAILS = {
+        "jobId": "12345",
+        "status": "SUCCEEDED",
+        "result": "created",
+        "resourceLink": "/resource/link",
+        "task": [{"description": "SRDF protect Storage Group test_sg"}],
+    }
+
+    REPLICATION_DETAILS_WITH_REMOTE_SGS = {
+        "storageGroupName": "test_sg",
+        "rdf_groups": [{"rdfGroupNumber": 1}],
+        "remote_storage_groups": [
+            {
+                "rdfGroupNumber": 1,
+                "remoteStorageGroupName": "DR_test_sg",
+                "remoteSymmetrixId": "000297900330",
+            }
+        ],
+    }
+
+    REPLICATION_DETAILS_MULTI_RDFG = {
+        "storageGroupName": "test_sg",
+        "rdf_groups": [{"rdfGroupNumber": 1}, {"rdfGroupNumber": 2}],
+        "remote_storage_groups": [
+            {
+                "rdfGroupNumber": 1,
+                "remoteStorageGroupName": "DR_test_sg_1",
+                "remoteSymmetrixId": "000297900330",
+            },
+            {
+                "rdfGroupNumber": 2,
+                "remoteStorageGroupName": "DR_test_sg_2",
+                "remoteSymmetrixId": "000297900331",
+            },
+        ],
+    }
+
+    REPLICATION_DETAILS_EMPTY_REMOTE_SGS = {
+        "storageGroupName": "test_sg",
+        "rdf_groups": [{"rdfGroupNumber": 1}],
+        "remote_storage_groups": [],
+    }
+
+    @staticmethod
+    def get_error_message(response_type, sg_name=None):
+        error_msg = {
+            "create_srdf_exception": f"Create srdf_link for sg {sg_name} failed with error",
+            "get_srdf_exception": f"Getting SRDF details for storage group {sg_name}",
+            "delete_srdf_exception": f"Delete srdf_link for sg {sg_name} failed with error",
+            "missing_params": "Mandatory parameters not found",
+            "bias_not_allowed": "Create SRDF link operation failed as Ansible modules v1.1 does not allow creation of SRDF links using Bias",
+        }
+        return error_msg[response_type]

--- a/tests/unit/plugins/modules/test_srdf.py
+++ b/tests/unit/plugins/modules/test_srdf.py
@@ -1,0 +1,139 @@
+# Copyright: (c) 2024-2025, Dell Technologies
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit Tests for SRDF module on PowerMax"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from mock.mock import MagicMock, patch
+from ansible_collections.dellemc.powermax.plugins.module_utils.storage.dell import utils
+from ansible.module_utils.compat.version import LooseVersion
+
+utils.get_logger = MagicMock()
+utils.has_pyu4v_sdk = MagicMock(return_value=True)
+utils.pyu4v_version_check = MagicMock(return_value=None)
+utils.get_U4V_connection = MagicMock()
+utils.close_connection = MagicMock()
+utils.parse_version = LooseVersion
+utils.PyU4V = MagicMock()
+utils.PyU4V.__version__ = "10.1.0.2"
+from ansible.module_utils import basic
+
+basic.AnsibleModule = MagicMock()
+
+
+from ansible_collections.dellemc.powermax.plugins.modules.srdf import (
+    SRDF,
+)
+from ansible_collections.dellemc.powermax.tests.unit.plugins.module_utils.mock_srdf_api import (
+    MockSRDFApi,
+)
+from ansible_collections.dellemc.powermax.tests.unit.plugins.module_utils.mock_api_exception import (
+    MockApiException,
+)
+from ansible_collections.dellemc.powermax.tests.unit.plugins.module_utils.shared_library.powermax_unit_base import (
+    PowerMaxUnitBase,
+)
+
+
+class TestSRDF(PowerMaxUnitBase):
+    srdf_args = MockSRDFApi.SRDF_COMMON_ARGS
+
+    @pytest.fixture
+    def module_object(self):
+        return SRDF
+
+    def test_get_srdf_link(self, powermax_module_mock):
+        """U-020: get_srdf_link returns SRDF details"""
+        powermax_module_mock.module.params = self.srdf_args
+        powermax_module_mock.replication.get_storage_group_srdf_details = MagicMock(
+            return_value=MockSRDFApi.SRDF_LINK_DETAILS
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        result = powermax_module_mock.get_srdf_link("test_sg")
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["storageGroupName"] == "test_sg"
+        powermax_module_mock.replication.get_storage_group_srdf_details.assert_called()
+
+    def test_get_srdf_link_exception(self, powermax_module_mock):
+        """U-020 error path: get_srdf_link handles exception"""
+        powermax_module_mock.module.params = self.srdf_args
+        powermax_module_mock.replication.get_storage_group_srdf_details = MagicMock(
+            side_effect=MockApiException
+        )
+        result = powermax_module_mock.get_srdf_link("test_sg")
+        assert result is None
+
+    def test_create_srdf_link_backward_compat(self, powermax_module_mock):
+        """U-019: create_srdf_link without rdf_target_sg_name uses default"""
+        args = dict(self.srdf_args)
+        args["rdf_target_sg_name"] = None
+        powermax_module_mock.module.params = args
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.replication.create_storage_group_srdf_pairings = MagicMock(
+            return_value=MockSRDFApi.JOB_DETAILS
+        )
+        result = powermax_module_mock.create_srdf_link()
+        assert result is True
+        powermax_module_mock.replication.create_storage_group_srdf_pairings.assert_called_once()
+        call_kwargs = powermax_module_mock.replication.create_storage_group_srdf_pairings.call_args
+        assert call_kwargs[1]["storage_group_id"] == "test_sg"
+
+    def test_create_srdf_link_with_rdf_target_sg_name(self, powermax_module_mock):
+        """U-018: create_srdf_link passes rdf_target_sg_name to SDK"""
+        args = dict(self.srdf_args)
+        args["rdf_target_sg_name"] = "DR_test_sg"
+        powermax_module_mock.module.params = args
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.replication.create_storage_group_srdf_pairings = MagicMock(
+            return_value=MockSRDFApi.JOB_DETAILS
+        )
+        result = powermax_module_mock.create_srdf_link()
+        assert result is True
+        powermax_module_mock.replication.create_storage_group_srdf_pairings.assert_called_once()
+
+    def test_create_srdf_link_empty_rdf_target(self, powermax_module_mock):
+        """U-E10: empty rdf_target_sg_name treated as None"""
+        args = dict(self.srdf_args)
+        args["rdf_target_sg_name"] = ""
+        powermax_module_mock.module.params = args
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.replication.create_storage_group_srdf_pairings = MagicMock(
+            return_value=MockSRDFApi.JOB_DETAILS
+        )
+        result = powermax_module_mock.create_srdf_link()
+        assert result is True
+
+    def test_create_srdf_link_exception(self, powermax_module_mock):
+        """U-E12: Exception in create_srdf_link handled"""
+        args = dict(self.srdf_args)
+        args["rdf_target_sg_name"] = None
+        powermax_module_mock.module.params = args
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.replication.create_storage_group_srdf_pairings = MagicMock(
+            side_effect=Exception("API error")
+        )
+        powermax_module_mock.show_error_exit = MagicMock()
+        powermax_module_mock.create_srdf_link()
+        powermax_module_mock.show_error_exit.assert_called_once()
+
+    def test_create_srdf_link_missing_params(self, powermax_module_mock):
+        """Baseline: create_srdf_link fails with missing mandatory params"""
+        args = dict(self.srdf_args)
+        args["remote_serial_no"] = None
+        args["srdf_mode"] = None
+        args["rdf_target_sg_name"] = None
+        powermax_module_mock.module.params = args
+        powermax_module_mock.show_error_exit = MagicMock()
+        powermax_module_mock.create_srdf_link()
+        assert powermax_module_mock.show_error_exit.called
+        # Check the first call (mandatory params check)
+        first_call_args = powermax_module_mock.show_error_exit.call_args_list[0]
+        assert "Mandatory parameters" in first_call_args[1]["msg"]

--- a/tests/unit/plugins/modules/test_srdf.py
+++ b/tests/unit/plugins/modules/test_srdf.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
-from mock.mock import MagicMock, patch
+from mock.mock import MagicMock
 from ansible_collections.dellemc.powermax.plugins.module_utils.storage.dell import utils
 from ansible.module_utils.compat.version import LooseVersion
 

--- a/tests/unit/plugins/modules/test_storagegroup.py
+++ b/tests/unit/plugins/modules/test_storagegroup.py
@@ -1831,3 +1831,210 @@ class TestStorageGroup(PowerMaxUnitBase):
         msg = "Error message"
         utils.close_connection = MagicMock(side_effect=MockApiException)
         self.capture_fail_json_method(msg, powermax_module_mock, "show_error_exit", msg)
+
+    # --- SRDF SG Naming Enhancement Tests ---
+
+    def test_add_volume_with_rdf_target_sg_name(self, powermax_module_mock):
+        """U-007: add_volume_storage_group uses explicit R2 name"""
+        sg_name = "test_sg"
+        srdf_protected_sg = dict(MockStorageGroupApi.STORAGEGROUP_RESPONSE_DETAILS)
+        srdf_protected_sg["unprotected"] = False
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "rdf_target_sg_name": "DR_test_sg",
+            "rdf_auto_resolve_target": False,
+            "volumes": [{"vol_name": "test_vol", "size": 1, "cap_unit": "GB"}],
+            "vol_state": "present-in-group",
+        })
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.provisioning.get_storage_group = MagicMock(
+            return_value=srdf_protected_sg
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.provisioning.get_volume_list = MagicMock(return_value=[])
+        powermax_module_mock.provisioning.add_new_volume_to_storage_group = MagicMock()
+        powermax_module_mock.common.get_array = MagicMock(
+            return_value={"ucode": "6079.999.999"}
+        )
+        powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
+        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        assert changed is True
+        call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
+        assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
+
+    def test_add_volume_with_auto_resolve(self, powermax_module_mock):
+        """U-008: add_volume_storage_group auto-resolves R2 name"""
+        sg_name = "test_sg"
+        srdf_protected_sg = dict(MockStorageGroupApi.STORAGEGROUP_RESPONSE_DETAILS)
+        srdf_protected_sg["unprotected"] = False
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "rdf_target_sg_name": None,
+            "rdf_auto_resolve_target": True,
+            "volumes": [{"vol_name": "test_vol", "size": 1, "cap_unit": "GB"}],
+            "vol_state": "present-in-group",
+        })
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.provisioning.get_storage_group = MagicMock(
+            return_value=srdf_protected_sg
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.replication.get_storage_group_replication_details = MagicMock(
+            return_value={
+                "remote_storage_groups": [
+                    {"rdfGroupNumber": 1, "remoteStorageGroupName": "DR_test_sg"}
+                ]
+            }
+        )
+        powermax_module_mock.provisioning.get_volume_list = MagicMock(return_value=[])
+        powermax_module_mock.provisioning.add_new_volume_to_storage_group = MagicMock()
+        powermax_module_mock.common.get_array = MagicMock(
+            return_value={"ucode": "6079.999.999"}
+        )
+        powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
+        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        assert changed is True
+        call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
+        assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
+
+    def test_add_volume_backward_compat(self, powermax_module_mock):
+        """U-009: add_volume_storage_group uses sg_name when no new params"""
+        sg_name = "test_sg"
+        srdf_protected_sg = dict(MockStorageGroupApi.STORAGEGROUP_RESPONSE_DETAILS)
+        srdf_protected_sg["unprotected"] = False
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "volumes": [{"vol_name": "test_vol", "size": 1, "cap_unit": "GB"}],
+            "vol_state": "present-in-group",
+        })
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.provisioning.get_storage_group = MagicMock(
+            return_value=srdf_protected_sg
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.provisioning.get_volume_list = MagicMock(return_value=[])
+        powermax_module_mock.provisioning.add_new_volume_to_storage_group = MagicMock()
+        powermax_module_mock.common.get_array = MagicMock(
+            return_value={"ucode": "6079.999.999"}
+        )
+        powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
+        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        assert changed is True
+        call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
+        assert call_kwargs[1]["remote_array_1_sgs"] == sg_name
+
+    def test_add_existing_vol_with_rdf_target(self, powermax_module_mock):
+        """U-010: add_existing_volumes_to_sg uses explicit R2 name"""
+        sg_name = "test_sg"
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "rdf_target_sg_name": "DR_test_sg",
+            "rdf_auto_resolve_target": False,
+            "volumes": [{"vol_id": "00001"}],
+            "vol_state": "present-in-group",
+        })
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.provisioning.get_volumes_from_storage_group = MagicMock(
+            return_value=[]
+        )
+        powermax_module_mock.provisioning.get_volume = MagicMock(
+            return_value={"volume_identifier": "vol_1", "cap_gb": 1}
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.provisioning.add_existing_volume_to_storage_group = MagicMock()
+        changed, _ = powermax_module_mock.add_existing_volumes_to_sg(
+            [{"vol_id": "00001"}], sg_name
+        )
+        assert changed is True
+        call_kwargs = powermax_module_mock.provisioning.add_existing_volume_to_storage_group.call_args
+        assert call_kwargs[1]["remote_array_1_sgs"] == ["DR_test_sg"]
+
+    def test_remove_vol_with_rdf_target(self, powermax_module_mock):
+        """U-011: remove_volumes_from_sg uses explicit R2 name"""
+        sg_name = "test_sg"
+        srdf_protected_sg = dict(MockStorageGroupApi.STORAGEGROUP_RESPONSE_DETAILS)
+        srdf_protected_sg["unprotected"] = False
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "rdf_target_sg_name": "DR_test_sg",
+            "rdf_auto_resolve_target": False,
+        })
+        powermax_module_mock.module.check_mode = False
+        powermax_module_mock.provisioning.get_volumes_from_storage_group = MagicMock(
+            return_value=["00001"]
+        )
+        powermax_module_mock.provisioning.get_storage_group = MagicMock(
+            return_value=srdf_protected_sg
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.provisioning.remove_volume_from_storage_group = MagicMock()
+        powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
+        changed, _ = powermax_module_mock.remove_volumes_from_sg(
+            [{"vol_id": "00001"}], sg_name
+        )
+        assert changed is True
+        call_kwargs = powermax_module_mock.provisioning.remove_volume_from_storage_group.call_args
+        assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
+
+    def test_add_volume_check_mode_with_rdf_target(self, powermax_module_mock):
+        """U-023: Check mode with rdf_target_sg_name makes no API calls"""
+        sg_name = "test_sg"
+        srdf_protected_sg = dict(MockStorageGroupApi.STORAGEGROUP_RESPONSE_DETAILS)
+        srdf_protected_sg["unprotected"] = False
+        powermax_module_mock.module.params = dict(self.storage_group_args)
+        powermax_module_mock.module.params.update({
+            "serial_no": "000197600156",
+            "rdf_target_sg_name": "DR_test_sg",
+            "rdf_auto_resolve_target": False,
+            "volumes": [{"vol_name": "test_vol", "size": 1, "cap_unit": "GB"}],
+            "vol_state": "present-in-group",
+        })
+        powermax_module_mock.module.check_mode = True
+        powermax_module_mock.provisioning.get_storage_group = MagicMock(
+            return_value=srdf_protected_sg
+        )
+        powermax_module_mock.replication.get_storage_group_srdf_group_list = MagicMock(
+            return_value=[1]
+        )
+        powermax_module_mock.replication.get_rdf_group = MagicMock(
+            return_value={"remoteSymmetrix": "000297900330"}
+        )
+        powermax_module_mock.provisioning.get_volume_list = MagicMock(return_value=[])
+        powermax_module_mock.provisioning.add_new_volume_to_storage_group = MagicMock()
+        powermax_module_mock.common.get_array = MagicMock(
+            return_value={"ucode": "6079.999.999"}
+        )
+        powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
+        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        assert changed is True
+        powermax_module_mock.provisioning.add_new_volume_to_storage_group.assert_not_called()

--- a/tests/unit/plugins/modules/test_storagegroup.py
+++ b/tests/unit/plugins/modules/test_storagegroup.py
@@ -1863,8 +1863,9 @@ class TestStorageGroup(PowerMaxUnitBase):
             return_value={"ucode": "6079.999.999"}
         )
         powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
-        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        changed, volume_details = powermax_module_mock.add_volume_storage_group(sg_name)
         assert changed is True
+        assert volume_details == []
         call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
         assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
 
@@ -1904,8 +1905,9 @@ class TestStorageGroup(PowerMaxUnitBase):
             return_value={"ucode": "6079.999.999"}
         )
         powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
-        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        changed, volume_details = powermax_module_mock.add_volume_storage_group(sg_name)
         assert changed is True
+        assert volume_details == []
         call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
         assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
 
@@ -1936,8 +1938,9 @@ class TestStorageGroup(PowerMaxUnitBase):
             return_value={"ucode": "6079.999.999"}
         )
         powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
-        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        changed, volume_details = powermax_module_mock.add_volume_storage_group(sg_name)
         assert changed is True
+        assert volume_details == []
         call_kwargs = powermax_module_mock.provisioning.add_new_volume_to_storage_group.call_args
         assert call_kwargs[1]["remote_array_1_sgs"] == sg_name
 
@@ -1966,10 +1969,11 @@ class TestStorageGroup(PowerMaxUnitBase):
             return_value={"remoteSymmetrix": "000297900330"}
         )
         powermax_module_mock.provisioning.add_existing_volume_to_storage_group = MagicMock()
-        changed, _ = powermax_module_mock.add_existing_volumes_to_sg(
+        changed, volume_details = powermax_module_mock.add_existing_volumes_to_sg(
             [{"vol_id": "00001"}], sg_name
         )
         assert changed is True
+        assert volume_details is not None
         call_kwargs = powermax_module_mock.provisioning.add_existing_volume_to_storage_group.call_args
         assert call_kwargs[1]["remote_array_1_sgs"] == ["DR_test_sg"]
 
@@ -1999,10 +2003,11 @@ class TestStorageGroup(PowerMaxUnitBase):
         )
         powermax_module_mock.provisioning.remove_volume_from_storage_group = MagicMock()
         powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
-        changed, _ = powermax_module_mock.remove_volumes_from_sg(
+        changed, volume_details = powermax_module_mock.remove_volumes_from_sg(
             [{"vol_id": "00001"}], sg_name
         )
         assert changed is True
+        assert volume_details == []
         call_kwargs = powermax_module_mock.provisioning.remove_volume_from_storage_group.call_args
         assert call_kwargs[1]["remote_array_1_sgs"] == "DR_test_sg"
 
@@ -2035,6 +2040,7 @@ class TestStorageGroup(PowerMaxUnitBase):
             return_value={"ucode": "6079.999.999"}
         )
         powermax_module_mock.get_volumes_details_storagegroup = MagicMock(return_value=[])
-        changed, _ = powermax_module_mock.add_volume_storage_group(sg_name)
+        changed, volume_details = powermax_module_mock.add_volume_storage_group(sg_name)
         assert changed is True
+        assert volume_details == []
         powermax_module_mock.provisioning.add_new_volume_to_storage_group.assert_not_called()


### PR DESCRIPTION
Add resolve_remote_sg_name() shared utility function to utils.py that resolves the remote (R2) storage group name using a priority chain: explicit rdf_target_sg_name > auto-resolve from array > fallback to local sg_name.

New module parameters (all optional, backward-compatible):
- rdf_target_sg_name: Explicit R2 storage group name
- rdf_auto_resolve_target: Auto-query array for actual R2 name

Updated modules:
- storagegroup.py: 8 callsites in add_volume, add_existing_volumes, remove_volumes (basic + multisite configurations)
- volume.py: 3 callsites in create_volume (basic + multisite)
- srdf.py: Parameter added to argument spec for SRDF link creation

Tests:
- New test_srdf.py with 7 unit tests for SRDF module
- 6 new tests in test_storagegroup.py for naming enhancement
- New mock_srdf_api.py with SRDF test data

Documentation:
- DOCUMENTATION strings updated in all 3 modules
- EXAMPLES added showing explicit and auto-resolve usage

All 13 SRDF naming tests pass.